### PR TITLE
Place cursor after math when closing popover

### DIFF
--- a/src/plugins/oer/math/lib/math-plugin.coffee
+++ b/src/plugins/oer/math/lib/math-plugin.coffee
@@ -86,6 +86,32 @@ define [ 'aloha', 'aloha/plugin', 'jquery', 'popover/popover-plugin', 'ui/ui', '
   Aloha.ready ->
     MathJax.Hub.Configured() if MathJax?
 
+  placeCursorAfter = (el) ->
+    # The selection-changed stuff in aloha incorrectly thinks we are
+    # still inside the math if we attempt to place the cursor JUST after it,
+    # so the best thing to do is add a wrapper element which we can focus. By
+    # marking this as aloha-ephemera-wrapper, the text inside it is unwrapped
+    # when the document is serialised.
+    n = el.next()
+    if n.is('span.math-element-spaceafter')
+      $tail = n
+    else
+      $tail = jQuery('<span class="math-element-spaceafter aloha-ephemera-wrapper"></span>')
+      el.after($tail)
+
+    # This will likely break in IE
+    range = document.createRange()
+    range.setStart($tail[0], 0)
+    range.collapse(true)
+
+    sel = window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    # Focus the editable in which el lives
+    el.parents('.aloha-editable').first().focus()
+
+
   getMathFor = (id) ->
     jax = MathJax?.Hub.getJaxFor id
     if jax
@@ -126,9 +152,6 @@ define [ 'aloha', 'aloha/plugin', 'jquery', 'popover/popover-plugin', 'ui/ui', '
         if mathParts.mimeType in MATHML_ANNOTATION_MIME_ENCODINGS
           addAnnotation $mathElement, mathParts.formula, mathParts.mimeType
         makeCloseIcon $mathElement
-        if not $mathElement.next().is '.aloha-ephemera-wrapper'
-          # a math meta-element needs to followed by a non-breaking space in a span
-          jQuery('<span class="aloha-ephemera-wrapper">&#160;</span>').insertAfter($mathElement)
 
     # What to when user clicks on math
     jQuery(editable.obj).on 'click.matheditor', '.math-element, .math-element *', (evt) ->
@@ -193,32 +216,18 @@ define [ 'aloha', 'aloha/plugin', 'jquery', 'popover/popover-plugin', 'ui/ui', '
       $el.trigger 'show'
       makeCloseIcon($el)
     else
-      # a math meta-element needs to followed by a non-breaking space in a span
-      $tail = jQuery('<span class="aloha-ephemera-wrapper">&#160;</span>')
       # Assume the user highlighted ASCIIMath (by putting the text in backticks)
       formula = range.getText()
       $el.find('.mathjax-wrapper').text(LANGUAGES['math/asciimath'].open +
                                         formula +
                                         LANGUAGES['math/asciimath'].close)
       GENTICS.Utils.Dom.removeRange range
-      GENTICS.Utils.Dom.insertIntoDOM $el.add($tail), range, Aloha.activeEditable.obj
+      GENTICS.Utils.Dom.insertIntoDOM $el, range, Aloha.activeEditable.obj
       triggerMathJax $el, ->
         addAnnotation $el, formula, 'math/asciimath'
         makeCloseIcon($el)
-
-        # This will likely break in IE
-        sel = window.getSelection()
-        r = sel.getRangeAt(0)
-        r.selectNodeContents($tail.parent().get(0))
-        r.setEndAfter($tail.get(0))
-        r.setStartAfter($tail.get(0))
-        sel.removeAllRanges()
-        sel.addRange(r)
-
-        # Let aloha know what we've done
-        r = new GENTICS.Utils.RangeObject()
-        r.update()
-        Aloha.Selection.rangeObject = r
+        Aloha.Selection.preventSelectionChanged()
+        placeCursorAfter($el)
         Aloha.activeEditable.smartContentChange {type: 'block-change'}
 
   # Register the button with an action
@@ -248,10 +257,8 @@ define [ 'aloha', 'aloha/plugin', 'jquery', 'popover/popover-plugin', 'ui/ui', '
     $editor = jQuery(EDITOR_HTML)
     # Bind some actions for the buttons
     $editor.find('.done').on 'click', =>
-      if not $span.next().is '.aloha-ephemera-wrapper'
-        # a math meta-element needs to followed by a non-breaking space in a span
-        jQuery('<span class="aloha-ephemera-wrapper">&#160;</span>').insertAfter($span)
       $span.trigger 'hide'
+      placeCursorAfter($span)
     $editor.find('.remove').on 'click', =>
       $span.trigger 'hide'
       cleanupFormula($editor, $span, true)

--- a/src/plugins/oer/math/lib/math-plugin.js
+++ b/src/plugins/oer/math/lib/math-plugin.js
@@ -3,7 +3,7 @@
   var __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   define(['aloha', 'aloha/plugin', 'jquery', 'popover/popover-plugin', 'ui/ui', 'css!../../../oer/math/css/math.css'], function(Aloha, Plugin, jQuery, Popover, UI) {
-    var EDITOR_HTML, LANGUAGES, MATHML_ANNOTATION_MIME_ENCODINGS, MATHML_ANNOTATION_NONMIME_ENCODINGS, SELECTOR, TOOLTIP_TEMPLATE, addAnnotation, buildEditor, cleanupFormula, findFormula, getEncoding, getMathFor, insertMath, makeCloseIcon, squirrelMath, triggerMathJax;
+    var EDITOR_HTML, LANGUAGES, MATHML_ANNOTATION_MIME_ENCODINGS, MATHML_ANNOTATION_NONMIME_ENCODINGS, SELECTOR, TOOLTIP_TEMPLATE, addAnnotation, buildEditor, cleanupFormula, findFormula, getEncoding, getMathFor, insertMath, makeCloseIcon, placeCursorAfter, squirrelMath, triggerMathJax;
 
     EDITOR_HTML = '<div class="math-editor-dialog">\n    <div class="math-container">\n        <pre><span></span><br></pre>\n        <textarea type="text" class="formula" rows="1"\n                  placeholder="Insert your math notation here"></textarea>\n    </div>\n    <div class="footer">\n      <span>This is:</span>\n      <label class="radio inline">\n          <input type="radio" name="mime-type" value="math/asciimath"> ASCIIMath\n      </label>\n      <label class="radio inline">\n          <input type="radio" name="mime-type" value="math/tex"> LaTeX\n      </label>\n      <label class="radio inline mime-type-mathml">\n          <input type="radio" name="mime-type" value="math/mml"> MathML\n      </label>\n      <label class="radio inline">\n          <input type="radio" name="mime-type" value="text/plain"> Plain text\n      </label>\n      <button class="btn btn-primary done">Done</button>\n    </div>\n</div>';
     LANGUAGES = {
@@ -36,6 +36,24 @@
         return MathJax.Hub.Configured();
       }
     });
+    placeCursorAfter = function(el) {
+      var $tail, n, range, sel;
+
+      n = el.next();
+      if (n.is('span.math-element-spaceafter')) {
+        $tail = n;
+      } else {
+        $tail = jQuery('<span class="math-element-spaceafter aloha-ephemera-wrapper"></span>');
+        el.after($tail);
+      }
+      range = document.createRange();
+      range.setStart($tail[0], 0);
+      range.collapse(true);
+      sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      return el.parents('.aloha-editable').first().focus();
+    };
     getMathFor = function(id) {
       var jax, mathStr;
 
@@ -77,10 +95,7 @@
           if (_ref1 = mathParts.mimeType, __indexOf.call(MATHML_ANNOTATION_MIME_ENCODINGS, _ref1) >= 0) {
             addAnnotation($mathElement, mathParts.formula, mathParts.mimeType);
           }
-          makeCloseIcon($mathElement);
-          if (!$mathElement.next().is('.aloha-ephemera-wrapper')) {
-            return jQuery('<span class="aloha-ephemera-wrapper">&#160;</span>').insertAfter($mathElement);
-          }
+          return makeCloseIcon($mathElement);
         });
       });
       jQuery(editable.obj).on('click.matheditor', '.math-element, .math-element *', function(evt) {
@@ -128,7 +143,7 @@
       }
     });
     insertMath = function() {
-      var $el, $tail, formula, range;
+      var $el, formula, range;
 
       $el = jQuery('<span class="math-element aloha-ephemera-wrapper"><span class="mathjax-wrapper aloha-ephemera">&#160;</span></span>');
       range = Aloha.Selection.getRangeObject();
@@ -137,26 +152,15 @@
         $el.trigger('show');
         return makeCloseIcon($el);
       } else {
-        $tail = jQuery('<span class="aloha-ephemera-wrapper">&#160;</span>');
         formula = range.getText();
         $el.find('.mathjax-wrapper').text(LANGUAGES['math/asciimath'].open + formula + LANGUAGES['math/asciimath'].close);
         GENTICS.Utils.Dom.removeRange(range);
-        GENTICS.Utils.Dom.insertIntoDOM($el.add($tail), range, Aloha.activeEditable.obj);
+        GENTICS.Utils.Dom.insertIntoDOM($el, range, Aloha.activeEditable.obj);
         return triggerMathJax($el, function() {
-          var r, sel;
-
           addAnnotation($el, formula, 'math/asciimath');
           makeCloseIcon($el);
-          sel = window.getSelection();
-          r = sel.getRangeAt(0);
-          r.selectNodeContents($tail.parent().get(0));
-          r.setEndAfter($tail.get(0));
-          r.setStartAfter($tail.get(0));
-          sel.removeAllRanges();
-          sel.addRange(r);
-          r = new GENTICS.Utils.RangeObject();
-          r.update();
-          Aloha.Selection.rangeObject = r;
+          Aloha.Selection.preventSelectionChanged();
+          placeCursorAfter($el);
           return Aloha.activeEditable.smartContentChange({
             type: 'block-change'
           });
@@ -196,10 +200,8 @@
 
       $editor = jQuery(EDITOR_HTML);
       $editor.find('.done').on('click', function() {
-        if (!$span.next().is('.aloha-ephemera-wrapper')) {
-          jQuery('<span class="aloha-ephemera-wrapper">&#160;</span>').insertAfter($span);
-        }
-        return $span.trigger('hide');
+        $span.trigger('hide');
+        return placeCursorAfter($span);
       });
       $editor.find('.remove').on('click', function() {
         $span.trigger('hide');


### PR DESCRIPTION
When closing the math popover, the cursor is placed after the math. If you mathify inline using ^m it skips the popover and places the cursor after the math. There was code to do this previously which didn't work that well, and which caused a proliferation of non-breaking space characters.
