### PR TITLE
Use internal browser cursors if available

### DIFF
--- a/src/plugins/oer/semanticblock/css/semanticblock-plugin.css
+++ b/src/plugins/oer/semanticblock/css/semanticblock-plugin.css
@@ -62,7 +62,7 @@
     display: none !important; /* override the default aloha display logic for handles */
     cursor: -moz-grab !important;
     cursor: -webkit-grab !important;
-    cursor: url('openhand.cur'), default; 
+    cursor: url('openhand.cur'), default;
 }
 .semantic-container.aloha-oer-dragging .aloha-block-handle {
     cursor: -moz-grabbing !important;


### PR DESCRIPTION
Use better internal cursors if available and use cursor files only as fallback mode for IE.
http://redmine.oerpub.org/issues/467
