### PR TITLE
refs #465: only put <P> element around orphaned media/image elements

### DIFF
--- a/src/plugins/oer/assorted/lib/image.coffee
+++ b/src/plugins/oer/assorted/lib/image.coffee
@@ -248,8 +248,22 @@ define ['aloha', 'jquery', 'aloha/plugin', 'image/image-plugin', 'ui/ui', 'seman
     element.append(img)
     element.attr('data-alt', img.attr('alt') || '')
 
-    # wrap the whole thing in a paragraph just so it passes the server's validation rules
-    element.parents('.semantic-container').wrap('<p>')
+    # image must be contained within a media element
+    $mediaset = element.closest('.media')
+    if $mediaset.length > 0
+      $media = jQuery($mediaset[0])
+      # media must be contained in :
+      # preformat (media must be block display), para, title, label, cite, cite-title, 
+      # link, emphasis, term, sub, sup, quote (media must be block display), foreign, 
+      # footnote, equation, note (media must be block display), item, code (media must be block display), 
+      # figure, subfigure, caption, commentary, meaning, entry, statement, proof, problem, 
+      # solution, content (media must be block display), section (media must be block display)
+      legalparents = $media.parents("figure, .para, .equation, .note, .quote")
+      if legalparents.length == 0
+        # media/image appears to be orphaned (via either user editing or block moving)
+        # add a p container to keep html canonical
+        element.parents('.semantic-container').wrap('<p class="para">')
+    return
 
   # Return config
   AlohaPlugin.create('oer-image', {

--- a/src/plugins/oer/assorted/lib/image.js
+++ b/src/plugins/oer/assorted/lib/image.js
@@ -224,12 +224,19 @@
       });
     };
     deactivate = function(element) {
-      var img;
+      var $media, $mediaset, img, legalparents;
       img = element.find('img');
       element.children().remove();
       element.append(img);
       element.attr('data-alt', img.attr('alt') || '');
-      return element.parents('.semantic-container').wrap('<p>');
+      $mediaset = element.closest('.media');
+      if ($mediaset.length > 0) {
+        $media = jQuery($mediaset[0]);
+        legalparents = $media.parents("figure, .para, .equation, .note, .quote");
+        if (legalparents.length === 0) {
+          element.parents('.semantic-container').wrap('<p class="para">');
+        }
+      }
     };
     return AlohaPlugin.create('oer-image', {
       init: function() {


### PR DESCRIPTION
We were unconditionally creating a <p> wrapper when we "deactivated" within the image plugin.  Added a check to make sure a legal parent for the media/image was missing, before adding the <p> wrapper.
