### PR TITLE
Math fixes 20130812

### DIFF
--- a/src/plugins/oer/math/lib/math-plugin.coffee
+++ b/src/plugins/oer/math/lib/math-plugin.coffee
@@ -114,21 +114,23 @@ define [ 'aloha', 'aloha/plugin', 'jquery', 'overlay/overlay-plugin', 'ui/ui', '
     el.parents('.aloha-editable').first().focus()
 
 
-  getMathFor = (id) ->
-    jax = MathJax?.Hub.getJaxFor id
+  getMathFor = (el) ->
+    jax = MathJax.Hub.getJaxFor el
     if jax
-      mathStr = jax.root.toMathML()
-      jQuery(mathStr)
+      return jQuery(jax.root.toMathML())
+    return null
 
   squirrelMath = ($el) ->
     # `$el` is the `.math-element`
 
-    $mml = getMathFor $el.find('script').attr('id')
-
-    # STEP3
-    $el.find('.mathml-wrapper').remove()
-    $mml.wrap '<span class="mathml-wrapper aloha-ephemera-wrapper"></span>'
-    $el.append $mml.parent()
+    $mml = getMathFor $el.find('script')[0]
+    if $mml != null
+      # STEP3
+      $el.find('.mathml-wrapper').remove()
+      $mml.wrap '<span class="mathml-wrapper aloha-ephemera-wrapper"></span>'
+      $el.append $mml.parent()
+    else
+      console?.warn($el, 'has no associated Jax. Does this happen too often?')
 
   Aloha.bind 'aloha-editable-created', (evt, editable) ->
     # Bind ctrl+m to math insert/mathify

--- a/src/plugins/oer/math/lib/math-plugin.js
+++ b/src/plugins/oer/math/lib/math-plugin.js
@@ -53,20 +53,24 @@
       sel.addRange(range);
       return el.parents('.aloha-editable').first().focus();
     };
-    getMathFor = function(id) {
-      var jax, mathStr;
-      jax = typeof MathJax !== "undefined" && MathJax !== null ? MathJax.Hub.getJaxFor(id) : void 0;
+    getMathFor = function(el) {
+      var jax;
+      jax = MathJax.Hub.getJaxFor(el);
       if (jax) {
-        mathStr = jax.root.toMathML();
-        return jQuery(mathStr);
+        return jQuery(jax.root.toMathML());
       }
+      return null;
     };
     squirrelMath = function($el) {
       var $mml;
-      $mml = getMathFor($el.find('script').attr('id'));
-      $el.find('.mathml-wrapper').remove();
-      $mml.wrap('<span class="mathml-wrapper aloha-ephemera-wrapper"></span>');
-      return $el.append($mml.parent());
+      $mml = getMathFor($el.find('script')[0]);
+      if ($mml !== null) {
+        $el.find('.mathml-wrapper').remove();
+        $mml.wrap('<span class="mathml-wrapper aloha-ephemera-wrapper"></span>');
+        return $el.append($mml.parent());
+      } else {
+        return typeof console !== "undefined" && console !== null ? console.warn($el, 'has no associated Jax. Does this happen too often?') : void 0;
+      }
     };
     Aloha.bind('aloha-editable-created', function(evt, editable) {
       var $maths;


### PR DESCRIPTION
A couple of fixes to the math plugin. One caused by Phil's removal of the preventDefault code some time ago, this caused the "delete" X to stop working. With the other code there seemed to be random cases where squirelling the math failed. After simplifying that code a bit, and explicitly calling return, the problem went away. Finally, if squirelling fail, rather log the problem instead of just breaking the whole process.
