### PR TITLE
fix sortable timing bug regarding editable activation

### DIFF
--- a/src/plugins/oer/semanticblock/lib/semanticblock-plugin.coffee
+++ b/src/plugins/oer/semanticblock/lib/semanticblock-plugin.coffee
@@ -274,13 +274,14 @@ define ['aloha', 'block/blockmanager', 'aloha/plugin', 'aloha/pluginmanager', 'j
         # theres no really good way to do this. editables get made into sortables
         # on `aloha-editable-created` and there is no event following that, so we 
         # just have to wait
-        setTimeout ->
-          if $root.is('.ui-sortable')
+        sortableInterval = setInterval ->
+          if $root.data 'sortable'
+            clearInterval(sortableInterval)
             $root.sortable 'option', 'stop', (e, ui) ->
               $root = jQuery(ui.item)
               activate $root if $root.is(selector)
             $root.sortable 'option', 'placeholder', 'aloha-oer-block-placeholder aloha-ephemera',
-          500
+          100
 
         if $root.is('.aloha-root-editable')
 

--- a/src/plugins/oer/semanticblock/lib/semanticblock-plugin.js
+++ b/src/plugins/oer/semanticblock/lib/semanticblock-plugin.js
@@ -260,7 +260,7 @@
           return jQuery(node).removeClass('aloha-block-dropzone aloha-editable aloha-block-blocklevel-sortable ui-sortable').removeAttr('contenteditable placeholder').get(0);
         });
         return Aloha.bind('aloha-editable-created', function(e, params) {
-          var $root, classes, selector, type, _i, _len;
+          var $root, classes, selector, sortableInterval, type, _i, _len;
           $root = params.obj;
           classes = [];
           for (_i = 0, _len = registeredTypes.length; _i < _len; _i++) {
@@ -268,8 +268,9 @@
             classes.push(type.selector);
           }
           selector = _this.settings.defaultSelector + ',' + classes.join();
-          setTimeout(function() {
-            if ($root.is('.ui-sortable')) {
+          sortableInterval = setInterval(function() {
+            if ($root.data('sortable')) {
+              clearInterval(sortableInterval);
               $root.sortable('option', 'stop', function(e, ui) {
                 $root = jQuery(ui.item);
                 if ($root.is(selector)) {
@@ -278,7 +279,7 @@
               });
               $root.sortable('option', 'placeholder', 'aloha-oer-block-placeholder aloha-ephemera');
             }
-            return 500;
+            return 100;
           });
           if ($root.is('.aloha-root-editable')) {
             $root.find(selector).each(function() {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/56802896

still not psyched about this fix... it might be worth PRing an event back into the aloha core that is thrown after the sortable is created. 

the real problem that kathi was experiencing was that some of the elements were committed back into the repo with the ui-sortable class on them. committing that class should be impossible now as it has been added to ephemera but just to support the dirty content i changed the conditional to check the object data instead of the class
