### PR TITLE
Show class name when hoveringover block of unknown type

### DIFF
--- a/src/plugins/oer/semanticblock/lib/semanticblock-plugin.coffee
+++ b/src/plugins/oer/semanticblock/lib/semanticblock-plugin.coffee
@@ -130,7 +130,7 @@ define ['aloha', 'block/blockmanager', 'aloha/plugin', 'aloha/pluginmanager', 'j
       else
         # Show the classes involved, filter out the aloha ones
         classes = (c for c in wrapped.attr('class').split(/\s+/) when not /^aloha/.test(c))
-        elementName = "element (class='#{classes.join(' ')}')"
+        elementName = classes.length and "element (class='#{classes.join(' ')}')" or 'element'
       jQuery(this).find('.aloha-block-handle').attr('title', "Drag this #{elementName} to another location.")
   ,
     name: 'mouseout'

--- a/src/plugins/oer/semanticblock/lib/semanticblock-plugin.js
+++ b/src/plugins/oer/semanticblock/lib/semanticblock-plugin.js
@@ -134,7 +134,7 @@
               }
               return _results;
             })();
-            elementName = "element (class='" + (classes.join(' ')) + "')";
+            elementName = classes.length && ("element (class='" + (classes.join(' ')) + "')") || 'element';
           }
           return jQuery(this).find('.aloha-block-handle').attr('title', "Drag this " + elementName + " to another location.");
         }


### PR DESCRIPTION
As requested, if the block is not recognised, show the class name of the block. This code carefully filters out aloha classes.
