### PR TITLE
Instead of hiding copy/paste buttons, merely disable.

### DIFF
--- a/src/plugins/oer/copy/lib/copy-plugin.coffee
+++ b/src/plugins/oer/copy/lib/copy-plugin.coffee
@@ -44,10 +44,10 @@ define ['aloha', 'aloha/plugin', 'jquery', 'ui/ui', 'ui/button', 'PubSub', './pa
       # handlers will be lost.
       jQuery('body').on 'enable-action', '.action.paste,.action.copy', (e) ->
         e.preventDefault()
-        jQuery(@).fadeIn('fast')
+        jQuery(@).prop('disabled', false)
       .on 'disable-action', '.action.paste,.action.copy', (e) ->
         e.preventDefault()
-        jQuery(@).fadeOut('fast')
+        jQuery(@).prop('disabled', true)
 
       # Copy becomes available when context is a heading
       focusHeading = null

--- a/src/plugins/oer/copy/lib/copy-plugin.js
+++ b/src/plugins/oer/copy/lib/copy-plugin.js
@@ -43,10 +43,10 @@
         plugin = this;
         jQuery('body').on('enable-action', '.action.paste,.action.copy', function(e) {
           e.preventDefault();
-          return jQuery(this).fadeIn('fast');
+          return jQuery(this).prop('disabled', false);
         }).on('disable-action', '.action.paste,.action.copy', function(e) {
           e.preventDefault();
-          return jQuery(this).fadeOut('fast');
+          return jQuery(this).prop('disabled', true);
         });
         focusHeading = null;
         PubSub.sub('aloha.selection.context-change', function(m) {


### PR DESCRIPTION
This avoids jitter in the UI, and is necessary to solve http://redmine.oerpub.org/issues/560.

The corresponding gh-book PR is here: https://github.com/oerpub/github-book/pull/46
