### PR TITLE
Image plugin warning icon and styling

### DIFF
--- a/src/plugins/oer/assorted/css/image.css
+++ b/src/plugins/oer/assorted/css/image.css
@@ -60,9 +60,10 @@ figure.aloha-oer-block .image-wrapper .image-edit {
     left: 100%;
     padding: 2px 10px 2px 5px;
     border-radius: 0 4px 4px 0;
-    width: 100px;
+    width: 20em;
     top: -8px;
     word-wrap: break-word;
+    line-height: 16px;
 }
 
 figure.aloha-oer-block .image-wrapper .image-edit:hover {
@@ -73,7 +74,6 @@ figure.aloha-oer-block .image-wrapper .image-edit:not(.passive):hover {
   border: 1px dotted #1B86D2;
   background-color: #D9E7F1;
   z-index: 400;
-  width: 100px;
   word-wrap: break-word;
 }
 
@@ -121,11 +121,13 @@ figure.aloha-oer-block .image-wrapper .image-edit.passive {
 i.icon-warning {
   display: inline-block;
   background-image: url(../img/warning-01.png);
-  background-position: 0 0;
+  background-position: 0 bottom;
+  background-repeat: no-repeat;
   margin-right: 4px;
   margin-left: 4px;
   width: 16px;
   height: 16px;
+  vertical-align: bottom;
 }
 
 .warning-text {


### PR DESCRIPTION
This restores the warning icon for missing description text. It also styles it a bit better I think, with the icon aligning better with the text, and the warning message slightly wider.
