### PR TITLE
Fix infinite recursion bug on tooltip/popover.

### DIFF
--- a/src/plugins/oer/math/lib/math-plugin.coffee
+++ b/src/plugins/oer/math/lib/math-plugin.coffee
@@ -386,6 +386,11 @@ define [ 'aloha', 'aloha/plugin', 'jquery', 'overlay/overlay-plugin', 'ui/ui', '
     $closer = $el.find '.math-element-destroy'
     if not $closer[0]?
       $closer = jQuery('<span class="math-element-destroy aloha-ephemera" title="Delete\u00A0math">&nbsp;</span>')
+      # The hidden event on the closeIcon should not propagate, otherwise it
+      # triggers cleanupFormula repeatedly on an empty math element, causing
+      # infinite recursion.
+      $closer.on 'hidden', (e) -> e.stopPropagation()
+
       if jQuery.ui and jQuery.ui.tooltip
         $closer.tooltip()
       else

--- a/src/plugins/oer/math/lib/math-plugin.js
+++ b/src/plugins/oer/math/lib/math-plugin.js
@@ -305,6 +305,9 @@
       $closer = $el.find('.math-element-destroy');
       if ($closer[0] == null) {
         $closer = jQuery('<span class="math-element-destroy aloha-ephemera" title="Delete\u00A0math">&nbsp;</span>');
+        $closer.on('hidden', function(e) {
+          return e.stopPropagation();
+        });
         if (jQuery.ui && jQuery.ui.tooltip) {
           $closer.tooltip();
         } else {


### PR DESCRIPTION
When the math popover is closed, it calls for the tooltip on the remove icon
to be destroyed. This causes a hide call on the tooltip, which causes a hidden
event on the icon, which propagates to the tooltip, triggering the entire
process again. By stopping this propagation, the error is avoided.
