### PR TITLE
make the "copy section" same/styling as other "copy [element]"s

### DIFF
--- a/src/plugins/oer/copy/css/copy.css
+++ b/src/plugins/oer/copy/css/copy.css
@@ -5,9 +5,14 @@ div.copy-section-controls {
 
 div.copy-section-controls span.copy-section {
     color: #666666;
-    font-size: 75%;
+    font-size: 11px;
     margin: 0 0.5em;
     cursor: pointer;
+    font-weight: normal;
+    letter-spacing: normal;
+}
+div.copy-section-controls span.copy-section .icon-copy:before {
+    font-size: 12px;
 }
 
 h1:hover div.copy-section-controls,


### PR DESCRIPTION
Coded at same time as https://github.com/oerpub/github-bookeditor/pull/79, but I don't think they necessarily have to be done together.
