### PR TITLE
remove ephemeral classes that were present on copy

### DIFF
--- a/src/plugins/oer/copy/lib/copy-plugin.coffee
+++ b/src/plugins/oer/copy/lib/copy-plugin.coffee
@@ -119,6 +119,9 @@ define ['aloha', 'aloha/plugin', 'jquery', 'ui/ui', 'ui/button', 'PubSub', './pa
 
           # Default paste behaviour follows
           $elements = jQuery plugin.getBuffer()
+          
+          # Remove any classes associated with previewing what element you were copying
+          $elements.removeClass('copy-preview focused')
 
           dstpath = plugin.getCurrentPath()
           if dstpath != null

--- a/src/plugins/oer/copy/lib/copy-plugin.js
+++ b/src/plugins/oer/copy/lib/copy-plugin.js
@@ -124,6 +124,7 @@
               return;
             }
             $elements = jQuery(plugin.getBuffer());
+            $elements.removeClass('copy-preview focused');
             dstpath = plugin.getCurrentPath();
             if (dstpath !== null) {
               dstpath = Path.dirname(dstpath);


### PR DESCRIPTION
It's possible this might have been better done on copy, but that part of the code looked more complicated to me.
