### PR TITLE
Implement setActiveButton, remove TODO code

### DIFF
--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.coffee
@@ -37,12 +37,25 @@ define [ 'jquery', 'aloha', 'aloha/plugin', 'PubSub', 'ui/button' ], (
           else
             btn.parent().addClass('disabled')
       disable: () -> @enable(false)
-      setActiveButton: (a, b) ->
-        console && console.log "#{slot} TODO:SETACTIVEBUTTON:", a, b
-      focus: (a) ->
-        console && console.log "#{slot} TODO:FOCUS:", a
-      foreground: (a) ->
-        console && console.log "#{slot} TODO:FOREGROUND:", a
+      setActiveButton: (subslot) ->
+        # Some aloha plugins (the format plugin) will register a multisplit
+        # button that contains other buttons. The setActiveButton call is used
+        # by that plugin to highlight the relevant nested button. At the moment
+        # we don't support any such use, but to provide some support for
+        # activating such a button, we will do the same thing we do for
+        # setActive, which is to look for a matching subaction.
+        if subslot
+          $ROOT.find(".action.#{slot} .subaction.#{subslot}").addClass(
+            'active')
+        else
+          $ROOT.find(".action.#{slot} .subaction.#{subslot}").removeClass(
+            'active')
+      focus: () ->
+        # When a UI component receives focus, this method is called to activate
+        # any child components. As this is not presently used, we simply do
+        # nothing.
+      foreground: () ->
+        # This is similar to focus above. Do nothing.
       flash: () ->
         # Allows a plugin to flash a button, thereby grabbing the user's
         # attention.

--- a/src/plugins/oer/toolbar/lib/toolbar-plugin.js
+++ b/src/plugins/oer/toolbar/lib/toolbar-plugin.js
@@ -58,17 +58,17 @@
           return this.enable(false);
         };
 
-        ItemRelay.prototype.setActiveButton = function(a, b) {
-          return console && console.log("" + slot + " TODO:SETACTIVEBUTTON:", a, b);
+        ItemRelay.prototype.setActiveButton = function(subslot) {
+          if (subslot) {
+            return $ROOT.find(".action." + slot + " .subaction." + subslot).addClass('active');
+          } else {
+            return $ROOT.find(".action." + slot + " .subaction." + subslot).removeClass('active');
+          }
         };
 
-        ItemRelay.prototype.focus = function(a) {
-          return console && console.log("" + slot + " TODO:FOCUS:", a);
-        };
+        ItemRelay.prototype.focus = function() {};
 
-        ItemRelay.prototype.foreground = function(a) {
-          return console && console.log("" + slot + " TODO:FOREGROUND:", a);
-        };
+        ItemRelay.prototype.foreground = function() {};
 
         ItemRelay.prototype.flash = function() {
           var el, evt, i, _i, _results;


### PR DESCRIPTION
We had no implementation for setActiveButton. This provides a simple
implementation that can be used for nested UI, but does nothing right now. Also removed logging for
the focus and foreground methods, and commented on their non-use.
