### PR TITLE
Avoid extra scrollbar in github-book.

### DIFF
--- a/src/plugins/common/paste/lib/paste-plugin.js
+++ b/src/plugins/common/paste/lib/paste-plugin.js
@@ -88,7 +88,7 @@ define([
 	 */
 	var $CLIPBOARD = $('<div style="position:absolute; ' +
 	                   'clip:rect(0px,0px,0px,0px); ' +
-	                   'width:1px; height:1px;"></div>').contentEditable(true);
+	                   'width:1px; height:1px; bottom:0;"></div>').contentEditable(true);
 
 	/**
 	 * Stored range, use to accomplish IE hack.


### PR DESCRIPTION
In some cases, adding an absolute div to the bottom of the document enlarges the document by 1px (thats's the height of the div) causing a scrollbar to appear where none is necessary. By pinning the div to the bottom, that 1px is inside the document. This is unlikely to negatively affect other applications.
