### PR TITLE
When the user leaves text hanging, complete the tag on blur

### DIFF
--- a/src/plugins/oer/metadata/lib/metadata-plugin.coffee
+++ b/src/plugins/oer/metadata/lib/metadata-plugin.coffee
@@ -481,6 +481,14 @@ define [
         title = @$_element.find('title').remove().text()
         @$_element.find(elements.title.selector).text(title)
 
+      # If the user leaves a value hanging without using one of the confirmKeys
+      # to complete the tag, complete it for him.
+      $('body').on 'blur', '#module-metadata-modal .bootstrap-tagsinput input', () ->
+        t = $(this).val()
+        if t
+          $(this).parent().prev().tagsinput('add', t)
+          $(this).val('')
+
       @$_element.click =>
         @_showModal()
 

--- a/src/plugins/oer/metadata/lib/metadata-plugin.js
+++ b/src/plugins/oer/metadata/lib/metadata-plugin.js
@@ -322,6 +322,14 @@
           title = this.$_element.find('title').remove().text();
           this.$_element.find(elements.title.selector).text(title);
         }
+        $('body').on('blur', '#module-metadata-modal .bootstrap-tagsinput input', function() {
+          var t;
+          t = $(this).val();
+          if (t) {
+            $(this).parent().prev().tagsinput('add', t);
+            return $(this).val('');
+          }
+        });
         return this.$_element.click(function() {
           return _this._showModal();
         });


### PR DESCRIPTION
The tags product depends on one of the `confirmKeys` to be pressed. This change
simply does the same thing if the text field is blurred.

This fixes #141.
