### PR TITLE
Fix browser crash

### DIFF
--- a/src/plugins/common/ui/lib/tab.js
+++ b/src/plugins/common/ui/lib/tab.js
@@ -143,11 +143,11 @@ define([
 		},
 
 		foreground: function() {
-			this.container.tabs('select', this.index);
+			//this.container.tabs('select', this.index);
 		},
 
 		childForeground: function(childComponent) {
-			this.foreground();
+			//this.foreground();
 		},
 
 		hasVisibleComponents: function () {
@@ -195,7 +195,7 @@ define([
 			}
 			this.handle.show();
 			this.visible = true;
-			
+
 			// Hiding all tabs may hide the toolbar, so showing the
 			// first tab again must also show the toolbar.
 			this.container.show();


### PR DESCRIPTION
jQueryUI.tabs will be "smart" and try to AJAX load tabs for you but webview's index.html contains a `<script>loading...</script>` which blows away the page as soon as it is added to the DOM.
