### PR TITLE
Optimize build size and include CSS into the build

### DIFF
--- a/build/aloha/build-profile-with-oer.js
+++ b/build/aloha/build-profile-with-oer.js
@@ -294,7 +294,8 @@
     //- "closure.keepLines": Same as closure option, but keeps line returns
     //in the minified files.
     //- "none": no minification will be done.
-    optimize: "none",
+    skipDirOptimize: true,
+    optimize: "uglify2",
 
     //If using UglifyJS for script optimization, these config options can be
     //used to pass configuration values to UglifyJS.
@@ -325,7 +326,7 @@
     //returns.  (r.js 1.0.8+)
     //- "standard.keepComments.keepLines": keeps the file comments and line
     //returns. (r.js 1.0.8+)
-    optimizeCss: "none",//"standard.keepLines",
+    optimizeCss: "standard",//"standard.keepLines",
 
     //If optimizeCss is in use, a list of of files to ignore for the @import
     //inlining. The value of this option should be a comma separated list
@@ -400,7 +401,7 @@
     // Put CSS in a separate file. None of the common aloha modules include
     // css dependencies, so this should cause only the oer css to be collected
     // into one file, in lib/aloha.css.
-    separateCSS: true,
+    separateCSS: false,
 
     //List the modules that will be optimized. All their immediate and deep
     //dependencies will be included in the module's file when the build is
@@ -448,7 +449,7 @@
                 'table/table-plugin',
                 'toolbar/toolbar-plugin',
                 'media-embed/media-embed-plugin'
-            ],
+            ]
         },
     ],
 
@@ -470,7 +471,7 @@
     //at the top of the file that points to the list of all the licenses.
     //This option will turn off the auto-preservation, but you will need
     //work out how best to surface the license information.
-    preserveLicenseComments: true,
+    preserveLicenseComments: false,
 
     //Sets the logging level. It is a number. If you want "silent" running,
     //set logLevel to 4. From the logger.js file:


### PR DESCRIPTION
Include CSS into the aloha.js build so that it does not have to be loaded separately, and reduce the compiled file size from ~2.1MB to ~777KB.
